### PR TITLE
Add missing wanikani study url all-info.user.js

### DIFF
--- a/userscripts/all-info.user.js
+++ b/userscripts/all-info.user.js
@@ -7,6 +7,7 @@
 // @match        https://www.wanikani.com/extra_study/session*
 // @match        https://www.wanikani.com/review/session*
 // @match        https://www.wanikani.com/subjects/*
+// @match        https://www.wanikani.com/subject-lessons/*
 // @match        https://preview.wanikani.com/extra_study/session*
 // @match        https://preview.wanikani.com/review/session*
 // @match        https://preview.wanikani.com/subjects*


### PR DESCRIPTION
This new URL is used when studying new contents, and the page has URLs as https://www.wanikani.com/subject-lessons/2094856555509408/quiz?queue=0086-2487-9997